### PR TITLE
update name and related URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,16 @@ Contributions are always welcome!
 
 ## Creating New Issues
 
-Do not hesitate and [create a new Issue](https://github.com/ipfs/ipfs-firefox-addon/issues/new) if you see a bug, room for improvement or simply have a question.
+Do not hesitate and [create a new Issue](https://github.com/ipfs/ipfs-companion/issues/new) if you see a bug, room for improvement or simply have a question.
 
 ## Working on existing Issues
 
-Feel free to work on issues that are [not assigned yet](https://github.com/ipfs/ipfs-firefox-addon/issues?utf8=✓&q=is%3Aissue+is%3Aopen+no%3Aassignee) and/or ones marked with [help wanted](https://github.com/ipfs/ipfs-firefox-addon/issues?q=is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) tag.  
+Feel free to work on issues that are [not assigned yet](https://github.com/ipfs/ipfs-companion/issues?utf8=✓&q=is%3Aissue+is%3Aopen+no%3Aassignee) and/or ones marked with [help wanted](https://github.com/ipfs/ipfs-companion/issues?q=is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) tag.  
 As a courtesy, please add a comment informing  about your intent. That way we will not duplicate effort.
 
 ## Submitting Pull Requests
 
-Just make sure your PR comes with its own tests and does pass [automated TravisCI tests](https://travis-ci.org/lidel/ipfs-firefox-addon/branches).
+Just make sure your PR comes with its own tests and does pass [automated TravisCI tests](https://travis-ci.org/ipfs/ipfs-companion/branches).
 See the [GitHub Flow Guide](https://guides.github.com/introduction/flow/) for details.
 
 Read section below to get familiar with tools and commands that will make your work easier.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 
 | **Important Announcement** :rocket: |
 | --- |
-| [Add-on is being migrated to the new Firefox API called WebExtensions](https://github.com/lidel/ipfs-firefox-addon/issues/20).  It will be released as `2.x.x`  |
-| Versions `1.x.x` are maintained in [legacy-sdk](https://github.com/lidel/ipfs-firefox-addon/tree/legacy-sdk) branch. |
+| [Add-on is being migrated to the new Firefox API called WebExtensions](https://github.com/ipfs/ipfs-companion/issues/20).  It will be released as `2.x.x`  |
+| Versions `1.x.x` are maintained in [legacy-sdk](https://github.com/ipfs/ipfs-companion/tree/legacy-sdk) branch. |
 
-# ipfs-firefox-addon AKA “IPFS Gateway Redirect”
+# IPFS Companion
 
 ![screenshot of v1.5.9](screenshot.png)
 
-[![](https://img.shields.io/github/release/lidel/ipfs-firefox-addon.svg)](https://github.com/lidel/ipfs-firefox-addon/releases/latest)
+[![](https://img.shields.io/github/release/ipfs/ipfs-companion.svg)](https://github.com/ipfs/ipfs-companion/releases/latest)
 [![](https://img.shields.io/badge/mozilla-full%20review-blue.svg)](https://addons.mozilla.org/en-US/firefox/addon/ipfs-gateway-redirect/)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-blue.svg)](http://standardjs.com/)
 [![NSP Status](https://nodesecurity.io/orgs/lidelorg/projects/db13ad1f-ca19-42c5-8c58-dbb8d111b651/badge)](https://nodesecurity.io/orgs/lidelorg/projects/db13ad1f-ca19-42c5-8c58-dbb8d111b651)
-[![build-status](https://travis-ci.org/lidel/ipfs-firefox-addon.svg?branch=master)](https://travis-ci.org/lidel/ipfs-firefox-addon)
-[![Coverage Status](https://coveralls.io/repos/github/lidel/ipfs-firefox-addon/badge.svg?branch=master)](https://coveralls.io/github/lidel/ipfs-firefox-addon?branch=master)
+[![build-status](https://travis-ci.org/ipfs/ipfs-companion.svg?branch=master)](https://travis-ci.org/ipfs/ipfs-companion)
+[![Coverage Status](https://coveralls.io/repos/github/ipfs/ipfs-companion/badge.svg?branch=master)](https://coveralls.io/github/ipfs/ipfs-companion?branch=master)
 
 > Firefox addon that provides transparent access to IPFS resources via local HTTP2IPFS gateway.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-blue.svg)](http://standardjs.com/)
 [![NSP Status](https://nodesecurity.io/orgs/lidelorg/projects/db13ad1f-ca19-42c5-8c58-dbb8d111b651/badge)](https://nodesecurity.io/orgs/lidelorg/projects/db13ad1f-ca19-42c5-8c58-dbb8d111b651)
 [![build-status](https://travis-ci.org/ipfs/ipfs-companion.svg?branch=master)](https://travis-ci.org/ipfs/ipfs-companion)
-[![Coverage Status](https://coveralls.io/repos/github/ipfs/ipfs-companion/badge.svg?branch=master)](https://coveralls.io/github/ipfs/ipfs-companion?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/lidel/ipfs-firefox-addon/badge.svg?branch=master)](https://coveralls.io/github/lidel/ipfs-firefox-addon?branch=master)
 
 > Firefox addon that provides transparent access to IPFS resources via local HTTP2IPFS gateway.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Security-conscious users should confirm that downloaded XPI package does match s
 Required steps:
 
 1. Download XPI package in version that is to be verified
-2. Checkout sources of the [same tag](https://github.com/lidel/ipfs-firefox-addon/tags)
+2. Checkout sources of the [same tag](https://github.com/ipfs/ipfs-companion/tags)
 2. Build XPI package from sources using `jpm xpi` command (`npm install jpm -g`).    
    As a result, you will have two XPI files which are in fact just ZIPs with different extension.   
 3. Unzip contents and compare manually or use handy one-liners below.

--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -5,7 +5,7 @@
     "version" : "2.0.5",
 
     "description": "Access IPFS resources via custom HTTP2IPFS gateway",
-    "homepage_url": "https://github.com/lidel/ipfs-firefox-addon",
+    "homepage_url": "https://github.com/ipfs/ipfs-companion",
     "author": "Marcin Rataj",
     "icons": {
         "19": "icons/png/ipfs-logo-on_19.png",

--- a/add-on/src/lib/common.js
+++ b/add-on/src/lib/common.js
@@ -303,7 +303,7 @@ function inFirefox () {
 async function addFromURL (info) {
   try {
     if (inFirefox()) {
-      // workaround due to https://github.com/lidel/ipfs-firefox-addon/issues/227
+      // workaround due to https://github.com/ipfs/ipfs-companion/issues/227
       const fetchOptions = {
         cache: 'force-cache',
         referrer: info.pageUrl
@@ -324,9 +324,9 @@ async function addFromURL (info) {
     console.error(`Error for ${contextMenuUploadToIpfs}`, error)
     if (error.message === 'NetworkError when attempting to fetch resource.') {
       notify('notify_uploadErrorTitle', 'notify_uploadTrackingProtectionErrorMsg')
-      console.warn('IPFS upload often fails because remote file can not be downloaded due to Tracking Protection. See details at: https://github.com/lidel/ipfs-firefox-addon/issues/227')
+      console.warn('IPFS upload often fails because remote file can not be downloaded due to Tracking Protection. See details at: https://github.com/ipfs/ipfs-companion/issues/227')
       browser.tabs.create({
-        'url': 'https://github.com/lidel/ipfs-firefox-addon/issues/227'
+        'url': 'https://github.com/ipfs/ipfs-companion/issues/227'
       })
     } else {
       notify('notify_uploadErrorTitle', 'notify_inlineErrorMsg', `${error.message}`)

--- a/add-on/src/lib/linkifyDOM.js
+++ b/add-on/src/lib/linkifyDOM.js
@@ -96,7 +96,7 @@
     if (href.startsWith('fs:')) {
       href = href.replace('fs:', '')
     }
-    href = 'https://ipfs.io/' + href // for now just point to public gw, we will switch to custom protocol when https://github.com/lidel/ipfs-firefox-addon/issues/164 is closed
+    href = 'https://ipfs.io/' + href // for now just point to public gw, we will switch to custom protocol when https://github.com/ipfs/ipfs-companion/issues/164 is closed
     href = href.replace(/([^:]\/)\/+/g, '$1') // remove redundant slashes
     return href
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "CC0-1.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lidel/ipfs-firefox-addon.git"
+    "url": "https://github.com/ipfs/ipfs-companion.git"
   },
   "scripts": {
     "start": "run-s clean build test firefox",


### PR DESCRIPTION
There were miscellaneous lingering references to ipfs/ipfs-firefox-addon (and even lidel/ipfs-firefox-addon!). This updates them to the new repository name.

This PR does _not_ change all references; I left those that seemed possibly entangled with AMO, with which I lack the expertise necessary to avoid breakage.