### PR TITLE
Refactoring of Browser Action and API Polling

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "IPFS Companion (Development Channel)",
     "short_name": "IPFS Companion",
-    "version" : "2.0.6",
+    "version" : "2.0.7",
 
     "description": "Access IPFS resources via custom HTTP2IPFS gateway",
     "homepage_url": "https://github.com/ipfs/ipfs-companion",

--- a/add-on/src/lib/common.js
+++ b/add-on/src/lib/common.js
@@ -14,9 +14,9 @@ async function init () {
     const options = await browser.storage.local.get(optionDefaults)
     ipfs = initIpfsApi(options.ipfsApiUrl)
     initStates(options)
-    restartAlarms(options)
     registerListeners()
     await storeMissingOptions(options, optionDefaults)
+    restartAlarms(options)
   } catch (error) {
     console.error('Unable to initialize addon due to error', error)
     notify('notify_addonIssueTitle', 'notify_addonIssueMsg')
@@ -274,7 +274,6 @@ async function sendStatusUpdateToBrowserAction () {
 // TODO: Remove use of alarms for signal passing, use PORTS instead
 
 const ipfsApiStatusUpdateAlarm = 'ipfs-api-status-update'
-const ipfsRedirectUpdateAlarm = 'ipfs-redirect-update'
 
 async function handleAlarm (alarm) {
   // avoid making expensive updates when IDLE
@@ -578,7 +577,6 @@ function onStorageChange (changes, area) { // eslint-disable-line no-unused-vars
         state.gwURLString = state.gwURL.toString()
       } else if (key === 'useCustomGateway') {
         state.redirect = change.newValue
-        browser.alarms.create(ipfsRedirectUpdateAlarm, {})
       } else if (key === 'linkify') {
         state.linkify = change.newValue
       } else if (key === 'automaticMode') {

--- a/add-on/src/popup/browser-action.js
+++ b/add-on/src/popup/browser-action.js
@@ -276,7 +276,7 @@ hide('quick-upload')
 hide('open-webui')
 
 function onDOMContentLoaded () {
-  // set up initial layout that will remain if there is no peers
+  // set up initial layout that will remain if there are no peers
   updateBrowserActionPopup()
   // initialize connection to the background script which will trigger UI updates
   port = browser.runtime.connect({name: 'browser-action-port'})


### PR DESCRIPTION
We had multiple issues with the way Alarms are implemented in Firefox and there are limitations under minimal interval in Chromium-based browsers.

This PR removes use of `browser.alarms.*` for triggering and signaling API status changes within background script and between background script and Browser Action popup.  

IPFS API polling is now handled by simple Interval, and communication with Browser Action popup uses `browser.runtime.*` APIs. 

This PR fixes #218, #259 and #243.
