### PR TITLE
feat: Poor Man's Protocol Handlers

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "IPFS Companion",
     "short_name": "IPFS Companion",
-    "version" : "2.0.9",
+    "version" : "2.0.10",
 
     "description": "Browser extension that simplifies access to IPFS resources",
     "homepage_url": "https://github.com/ipfs/ipfs-companion",

--- a/add-on/src/lib/option-defaults.js
+++ b/add-on/src/lib/option-defaults.js
@@ -7,6 +7,7 @@ const optionDefaults = Object.freeze({ // eslint-disable-line no-unused-vars
   automaticMode: true,
   linkify: false,
   dnslink: false,
+  catchUnhandledProtocols: true,
   customGatewayUrl: 'http://127.0.0.1:8080',
   ipfsApiUrl: 'http://127.0.0.1:5001',
   ipfsApiPollMs: 3000

--- a/add-on/src/lib/option-defaults.js
+++ b/add-on/src/lib/option-defaults.js
@@ -8,6 +8,7 @@ const optionDefaults = Object.freeze({ // eslint-disable-line no-unused-vars
   linkify: false,
   dnslink: false,
   catchUnhandledProtocols: true,
+  displayNotifications: true,
   customGatewayUrl: 'http://127.0.0.1:8080',
   ipfsApiUrl: 'http://127.0.0.1:5001',
   ipfsApiPollMs: 3000

--- a/add-on/src/options/options.html
+++ b/add-on/src/options/options.html
@@ -142,7 +142,7 @@
           <label for="catchUnhandledProtocols">
             <dl>
               <dt>Catch Unhandled IPFS Protocols</dt>
-              <dd>Enables support for <code>ipfs://</code>, <code>ipns://</code> and <code>dweb://</code> by catching and normalizing requests done with unhandled protocols</dd>
+              <dd>Enables support for <code>ipfs://$cid</code>, <code>ipns://$peerid</code> and <code>dweb:/ipfs/$cid</code> by catching and normalizing requests done with unhandled protocols</dd>
             </dl>
           </label>
           <input type="checkbox" id="catchUnhandledProtocols" />

--- a/add-on/src/options/options.html
+++ b/add-on/src/options/options.html
@@ -150,7 +150,7 @@
         <div>
           <label for="linkify">
             <dl>
-              <dt>Clickable IPFS Addresses</dt>
+              <dt>Linkify IPFS Addresses</dt>
               <dd>Turn plaintext <code>/ipfs/</code> paths into clickable links</dd>
             </dl>
           </label>

--- a/add-on/src/options/options.html
+++ b/add-on/src/options/options.html
@@ -139,6 +139,15 @@
         <legend>Experiments</legend>
         <div><span><strong>Note:</strong> these features are work-in-progress and may degrade browser performance. <abbr title="Your Mileage May Vary">YMMV</abbr>.</span></div>
         <div>
+          <label for="catchUnhandledProtocols">
+            <dl>
+              <dt>Catch Unhandled IPFS Protocols</dt>
+              <dd>Enables support for <code>ipfs://</code>, <code>ipns://</code> and <code>dweb://</code> by catching and normalizing requests done with unhandled protocols</dd>
+            </dl>
+          </label>
+          <input type="checkbox" id="catchUnhandledProtocols" />
+        </div>
+        <div>
           <label for="linkify">
             <dl>
               <dt>Clickable IPFS Addresses</dt>

--- a/add-on/src/options/options.html
+++ b/add-on/src/options/options.html
@@ -137,7 +137,16 @@
     <form>
       <fieldset>
         <legend>Experiments</legend>
-        <div><span><strong>Note:</strong> these features are work-in-progress and may degrade browser performance. <abbr title="Your Mileage May Vary">YMMV</abbr>.</span></div>
+        <div><span><strong>Note:</strong> these features are new or work-in-progress. <abbr title="Your Mileage May Vary">YMMV</abbr>.</span></div>
+        <div>
+          <label for="displayNotifications">
+            <dl>
+              <dt>Enable Notifications</dt>
+              <dd>Displays system notifications when API state changes, a link is copied etc</dd>
+            </dl>
+          </label>
+          <input type="checkbox" id="displayNotifications" />
+        </div>
         <div>
           <label for="catchUnhandledProtocols">
             <dl>

--- a/package.json
+++ b/package.json
@@ -52,19 +52,19 @@
     "karma-mocha": "1.3.0",
     "karma-mocha-reporter": "2.2.4",
     "karma-sinon": "1.0.5",
-    "mocha": "3.5.0",
+    "mocha": "3.5.3",
     "npm-run-all": "4.1.1",
     "selenium-webdriver": "3.5.0",
     "shx": "0.2.2",
-    "sinon": "3.2.1",
+    "sinon": "4.0.0",
     "standard": "10.0.3",
     "sinon-chrome": "2.2.1",
     "web-ext": "2.0.0"
   },
   "dependencies": {
-    "ipfs-api": "14.3.4",
+    "ipfs-api": "14.3.5",
     "is-ipfs": "0.3.2",
     "lru_map": "0.3.3",
-    "webextension-polyfill": "0.1.1"
+    "webextension-polyfill": "0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postcheckout": "npm update && run-s clean build:copy*",
     "postmerge": "run-s postcheckout",
     "precommit": "run-s -s clean lint build",
-    "prepush": "run-s -s precommit test",
+    "prepush": "run-s -s precommit test build",
     "firefox": "web-ext run -s add-on/ --browser-console"
   },
   "private": true,

--- a/test/unit/00-init.test.js
+++ b/test/unit/00-init.test.js
@@ -48,7 +48,7 @@ describe('init.js', function () {
   })
 
   describe('onStorageChange()', function () {
-    it('should update ipfs API instance on IPFS API URL change', done => {
+    it('should update ipfs API instance on IPFS API URL change', function () {
       const oldIpfsApiUrl = 'http://127.0.0.1:5001'
       const newIpfsApiUrl = 'http://1.2.3.4:8080'
       const changes = {ipfsApiUrl: {oldValue: oldIpfsApiUrl, newValue: newIpfsApiUrl}}
@@ -59,7 +59,6 @@ describe('init.js', function () {
       onStorageChange(changes, area)
       sinon.assert.calledOnce(IpfsApi)
       sinon.assert.calledWith(IpfsApi, newCfg)
-      done()
     })
   })
 

--- a/test/unit/01-onBeforeRequest.test.js
+++ b/test/unit/01-onBeforeRequest.test.js
@@ -49,111 +49,111 @@ describe('onBeforeRequest', function () {
   })
 
   describe('request made via "web+" handler from manifest.json/protocol_handlers', function () {
-    it('should not be normalized if URI is web+ipfs:/{CID}', function () {
+    it('should not be normalized if web+ipfs:/{CID}', function () {
       const request = url2request('https://ipfs.io/web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+ipfs://{CID}', function () {
+    it('should be normalized if web+ipfs://{CID}', function () {
       const request = url2request('https://ipfs.io/web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should not be normalized if URI is web+ipns:/{foo}', function () {
+    it('should not be normalized if web+ipns:/{foo}', function () {
       const request = url2request('https://ipfs.io/web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+ipns://{foo}', function () {
+    it('should be normalized if web+ipns://{foo}', function () {
       const request = url2request('https://ipfs.io/web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
     })
-    it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
+    it('should be normalized if web+dweb:/ipfs/{CID}', function () {
       const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should not be normalized if URI is web+dweb://ipfs/{CID}', function () {
+    it('should not be normalized if web+dweb://ipfs/{CID}', function () {
       const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
+    it('should be normalized if web+dweb:/ipns/{foo}', function () {
       const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
     })
-    it('should not be normalized if URI is web+dweb://ipns/{foo}', function () {
+    it('should not be normalized if web+dweb://ipns/{foo}', function () {
       const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should not be normalized if URI is web+{foo}:/bar', function () {
+    it('should not be normalized if web+{foo}:/bar', function () {
       const request = url2request('https://ipfs.io/web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should not be normalized if URI is web+{foo}://bar', function () {
+    it('should not be normalized if web+{foo}://bar', function () {
       const request = url2request('https://ipfs.io/web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
   })
 
   describe('catching unhandled custom protocol request', function () {
-    it('should not be normalized if URI is ipfs:/{CID}', function () {
+    it('should not be normalized if ipfs:/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is ipfs://{CID}', function () {
+    it('should be normalized if ipfs://{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should not be normalized if URI is ipns:/{foo}', function () {
+    it('should not be normalized if ipns:/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is ipns://{foo}', function () {
+    it('should be normalized if ipns://{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
     })
-    it('should be normalized if URI is dweb:/ipfs/{CID}', function () {
+    it('should be normalized if dweb:/ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
     })
-    it('should not be normalized if URI is dweb://ipfs/{CID}', function () {
+    it('should not be normalized if dweb://ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is dweb:/ipns/{foo}', function () {
+    it('should be normalized if dweb:/ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
     })
-    it('should not be normalized if URI is dweb://ipns/{foo}', function () {
+    it('should not be normalized if dweb://ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       should.not.exist(onBeforeRequest(request))
     })
 
-    it('should not be normalized if URI is web+ipfs:/{CID}', function () {
+    it('should not be normalized if web+ipfs:/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+ipfs://{CID}', function () {
+    it('should be normalized if web+ipfs://{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should not be normalized if URI is web+ipns:/{foo}', function () {
+    it('should not be normalized if web+ipns:/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+ipns://{foo}', function () {
+    it('should be normalized if web+ipns://{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
     })
-    it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
+    it('should be normalized if web+dweb:/ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
     })
-    it('should not be normalized if URI is web+dweb://ipfs/{CID}', function () {
+    it('should not be normalized if web+dweb://ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
+    it('should be normalized if web+dweb:/ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
     })
-    it('should not be normalized if URI is web+dweb://ipns/{foo}', function () {
+    it('should not be normalized if web+dweb://ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       should.not.exist(onBeforeRequest(request))
     })

--- a/test/unit/01-onBeforeRequest.test.js
+++ b/test/unit/01-onBeforeRequest.test.js
@@ -1,0 +1,227 @@
+'use strict'
+/* eslint-env webextensions, mocha */
+/* globals sinon, optionDefaults, should, state, onBeforeRequest */
+
+var sandbox
+
+const url2request = (string) => {
+  return {url: string}
+}
+
+describe('onBeforeRequest', function () {
+  beforeEach(() => {
+    browser.flush()
+    sandbox = sinon.sandbox.create()
+    browser.storage.local.get.returns(Promise.resolve(optionDefaults))
+    // redirect by default -- makes test code shorter
+    state.redirect = true
+    state.catchUnhandledProtocols = true
+    state.gwURLString = 'http://127.0.0.1:8080'
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    browser.flush()
+  })
+
+  describe('request for a path matching /ipfs/{CIDv0}', function () {
+    it('should be served from custom gateway if redirect is enabled', function () {
+      const request = url2request('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be left untouched if redirect is disabled', function () {
+      state.redirect = false
+      const request = url2request('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      should.not.exist(onBeforeRequest(request))
+    })
+  })
+
+  describe('request for a path matching /ipns/{path}', function () {
+    it('should be served from custom gateway if redirect is enabled', function () {
+      const request = url2request('https://ipfs.io/ipns/ipfs.io/index.html?argTest#hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('http://127.0.0.1:8080/ipns/ipfs.io/index.html?argTest#hashTest')
+    })
+    it('should be left untouched if redirect is disabled', function () {
+      state.redirect = false
+      const request = url2request('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+      should.not.exist(onBeforeRequest(request))
+    })
+  })
+
+  describe('request made via "web+" handler from manifest.json/protocol_handlers', function () {
+    it('should be normalized if URI is web+ipfs:/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipfs:/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+ipfs://{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+ipns:/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipns:/ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+ipns://{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipns://ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+fs:/ipfs/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bfs:/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+fs://ipfs/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bfs://ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+fs:/ipns/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bfs:/ipns/ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+fs://ipns/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bfs://ipns/ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb:/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+dweb://ipfs/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb://ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb:/ipns/ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+dweb://ipns/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb://ipns/ipfs.io%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+{foo}:/bar', function () {
+      const request = url2request('https://ipfs.io/web%2Bfoo:/bar%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/foo/bar?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+{foo}://bar', function () {
+      const request = url2request('https://ipfs.io/web%2Bfoo://bar%3FargTest%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/foo/bar?argTest#hashTest')
+    })
+  })
+
+  // TODO: add tests for unhandled protocol schemes:
+  // - google, duck duck go, bing, baidu, yandex
+  describe('unhandled custom protocol request', function () {
+    it('should be normalized if URI is ipfs:/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is ipfs://{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is ipns:/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=ipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+    })
+    it('should be normalized if URI is ipns://{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=ipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+    })
+    it('should be normalized if URI is fs:/ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=fs%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is fs://ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=fs%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is fs:/ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=fs%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is fs://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=fs%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is dweb:/ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is dweb://ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is dweb:/ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is dweb://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+
+    it('should be normalized if URI is web+ipfs:/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+ipfs://{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should be normalized if URI is web+ipns:/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+    })
+    it('should be normalized if URI is web+ipns://{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+    })
+    it('should be normalized if URI is web+fs:/ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+fs://ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+fs:/ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+fs://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+dweb://ipfs/{CID}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should be normalized if URI is web+dweb://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+
+    it('should not be normalized if disabled in Preferences', function () {
+      state.catchUnhandledProtocols = false
+      const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
+      should.not.exist(onBeforeRequest(request))
+    })
+    it('should not be normalized if CID is invalid', function () {
+      state.catchUnhandledProtocols = false
+      const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2FnotARealIpfsPathWithCid%3FargTest%23hashTest&foo=bar')
+      should.not.exist(onBeforeRequest(request))
+    })
+    it('should not be normalized if presence of %3A%2F is a false-positive', function () {
+      state.catchUnhandledProtocols = false
+      const request = url2request('https://duckduckgo.com/?q=foo%3A%2Fbar%3FargTest%23hashTest&foo=bar')
+      should.not.exist(onBeforeRequest(request))
+    })
+  })
+})

--- a/test/unit/01-onBeforeRequest.test.js
+++ b/test/unit/01-onBeforeRequest.test.js
@@ -49,163 +49,113 @@ describe('onBeforeRequest', function () {
   })
 
   describe('request made via "web+" handler from manifest.json/protocol_handlers', function () {
-    it('should be normalized if URI is web+ipfs:/{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bipfs:/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    it('should not be normalized if URI is web+ipfs:/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+ipfs://{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      const request = url2request('https://ipfs.io/web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should be normalized if URI is web+ipns:/{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bipns:/ipfs.io%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    it('should not be normalized if URI is web+ipns:/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+ipns://{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bipns://ipfs.io%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
-    })
-    it('should be normalized if URI is web+fs:/ipfs/{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bfs:/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
-    })
-    it('should be normalized if URI is web+fs://ipfs/{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bfs://ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
-    })
-    it('should be normalized if URI is web+fs:/ipns/{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bfs:/ipns/ipfs.io%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
-    })
-    it('should be normalized if URI is web+fs://ipns/{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bfs://ipns/ipfs.io%3FargTest%23hashTest')
+      const request = url2request('https://ipfs.io/web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
     })
     it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bdweb:/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should be normalized if URI is web+dweb://ipfs/{CID}', function () {
-      const request = url2request('https://ipfs.io/web%2Bdweb://ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    it('should not be normalized if URI is web+dweb://ipfs/{CID}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bdweb:/ipns/ipfs.io%3FargTest%23hashTest')
+      const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
     })
-    it('should be normalized if URI is web+dweb://ipns/{foo}', function () {
-      const request = url2request('https://ipfs.io/web%2Bdweb://ipns/ipfs.io%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+    it('should not be normalized if URI is web+dweb://ipns/{foo}', function () {
+      const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+{foo}:/bar', function () {
-      const request = url2request('https://ipfs.io/web%2Bfoo:/bar%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/foo/bar?argTest#hashTest')
+    it('should not be normalized if URI is web+{foo}:/bar', function () {
+      const request = url2request('https://ipfs.io/web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
-    it('should be normalized if URI is web+{foo}://bar', function () {
-      const request = url2request('https://ipfs.io/web%2Bfoo://bar%3FargTest%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/foo/bar?argTest#hashTest')
+    it('should not be normalized if URI is web+{foo}://bar', function () {
+      const request = url2request('https://ipfs.io/web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
   })
 
-  // TODO: add tests for unhandled protocol schemes:
-  // - google, duck duck go, bing, baidu, yandex
-  describe('unhandled custom protocol request', function () {
-    it('should be normalized if URI is ipfs:/{CID}', function () {
+  describe('catching unhandled custom protocol request', function () {
+    it('should not be normalized if URI is ipfs:/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is ipfs://{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should be normalized if URI is ipns:/{foo}', function () {
+    it('should not be normalized if URI is ipns:/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is ipns://{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=ipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
     })
-    it('should be normalized if URI is fs:/ipfs/{CID}', function () {
-      const request = url2request('https://duckduckgo.com/?q=fs%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is fs://ipfs/{CID}', function () {
-      const request = url2request('https://duckduckgo.com/?q=fs%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is fs:/ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=fs%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is fs://ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=fs%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
     it('should be normalized if URI is dweb:/ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
     })
-    it('should be normalized if URI is dweb://ipfs/{CID}', function () {
+    it('should not be normalized if URI is dweb://ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is dweb:/ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is dweb://ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=dweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
     })
+    it('should not be normalized if URI is dweb://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=dweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      should.not.exist(onBeforeRequest(request))
+    })
 
-    it('should be normalized if URI is web+ipfs:/{CID}', function () {
+    it('should not be normalized if URI is web+ipfs:/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+ipfs://{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-    it('should be normalized if URI is web+ipns:/{foo}', function () {
+    it('should not be normalized if URI is web+ipns:/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+ipns://{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bipns%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest')
     })
-    it('should be normalized if URI is web+fs:/ipfs/{CID}', function () {
-      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is web+fs://ipfs/{CID}', function () {
-      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is web+fs:/ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is web+fs://ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=web%2Bfs%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
     it('should be normalized if URI is web+dweb:/ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
     })
-    it('should be normalized if URI is web+dweb://ipfs/{CID}', function () {
+    it('should not be normalized if URI is web+dweb://ipfs/{CID}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipfs%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=software')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?arg=foo&bar=buzz#hash')
+      should.not.exist(onBeforeRequest(request))
     })
     it('should be normalized if URI is web+dweb:/ipns/{foo}', function () {
-      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
-      onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
-    })
-    it('should be normalized if URI is web+dweb://ipns/{foo}', function () {
       const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
       onBeforeRequest(request).redirectUrl.should.equal('https://ipfs.io/ipns/ipfs.io/index.html?arg=foo&bar=buzz#hash')
+    })
+    it('should not be normalized if URI is web+dweb://ipns/{foo}', function () {
+      const request = url2request('https://duckduckgo.com/?q=web%2Bdweb%3A%2F%2Fipns%2Fipfs.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hash&ia=web')
+      should.not.exist(onBeforeRequest(request))
     })
 
     it('should not be normalized if disabled in Preferences', function () {


### PR DESCRIPTION
This is an implementation of ridiculous idea from https://github.com/ipfs/ipfs-companion/issues/164#issuecomment-328374052
I am really sorry, but its the only way to get `dweb://` working across all browsers  🙄  

----

As usual, I am not sure how to label checkbox responsible for toggling this feature in _Preferences_.
Current label looks like this:

> ![2017-09-17-024645_537x81_scrot](https://user-images.githubusercontent.com/157609/30517083-66f32544-9b53-11e7-84a3-789395c7ac8f.png)

Any ideas how to improve it before I merge this PR?
 