### PR TITLE
Normalize dweb: in href and src

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "IPFS Companion",
     "short_name": "IPFS Companion",
-    "version" : "2.0.11",
+    "version" : "2.0.12",
 
     "description": "Browser extension that simplifies access to IPFS resources",
     "homepage_url": "https://github.com/ipfs/ipfs-companion",

--- a/add-on/src/lib/normalizeLinksWithUnhandledProtocols.js
+++ b/add-on/src/lib/normalizeLinksWithUnhandledProtocols.js
@@ -1,0 +1,93 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+/*
+ * This content script detects IPFS-related protocols in `href` and `src`
+ * attributes and replaces them with URL at the user-specified public HTTP gateway.
+ * Note that if IPFS API is online, HTTP request will be redirected to custom gateway.
+ *
+ * For more background see: https://github.com/ipfs/ipfs-companion/issues/286
+ *
+ * Test page: http://bit.ly/2hXiuUz
+ */
+
+;(function (alreadyLoaded) {
+  if (alreadyLoaded) {
+    return
+  }
+
+  // Limit contentType to "text/plain" or "text/html"
+  if (document.contentType !== undefined && document.contentType !== 'text/plain' && document.contentType !== 'text/html') {
+    return
+  }
+
+  // prevent double init
+  window.ipfsCompanionNormalizedUnhandledProtocols = true
+
+  // XPath selects all elements that have `href` of `src` attribute starting with one of IPFS-related protocols
+  const xpath = ".//*[starts-with(@href, 'ipfs://') or starts-with(@href, 'ipns://') or starts-with(@href, 'dweb:') " +
+                " or starts-with(@src, 'ipfs://') or starts-with(@src, 'ipns://') or starts-with(@src, 'dweb:')]"
+
+  const pubGwURL = window.ipfsCompanionPubGwURL
+
+  function init () {
+    // initial run
+    normalizeTree(document.body)
+
+    // listen for future DOM changes
+    new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'childList') {
+          for (let addedNode of mutation.addedNodes) {
+            if (addedNode.nodeType === Node.ELEMENT_NODE) {
+              setTimeout(() => normalizeTree(addedNode), 0)
+            }
+          }
+        }
+      })
+    }).observe(document.body, {
+      characterData: false,
+      childList: true,
+      subtree: true
+    })
+  }
+
+  function normalizeElement (element) {
+    if (element.href) {
+      // console.log('normalizeElement.href: ' + element.href)
+      element.href = normalizeAddress(element.href)
+    } else if (element.src) {
+      // console.log('normalizeElement.src: ' + element.src)
+      element.src = normalizeAddress(element.src)
+    }
+  }
+
+  // replaces unhandled protocol with a regular URL at a public gateway
+  function normalizeAddress (addr) {
+    return addr
+      .replace(/^dweb:\//i, pubGwURL) // dweb:/ipfs/Qm → /ipfs/Qm
+      .replace(/^ipfs:\/\//i, `${pubGwURL}ipfs/`) // ipfs://Qm → /ipfs/Qm
+      .replace(/^ipns:\/\//i, `${pubGwURL}ipns/`) // ipns://Qm → /ipns/Qm
+  }
+
+  function normalizeTree (root) {
+    const xpathResult = document.evaluate(xpath, root, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)
+    let i = 0
+    function continuation () {
+      let node = null
+      let counter = 0
+      while ((node = xpathResult.snapshotItem(i++))) {
+        const parent = node.parentNode
+        // Skip if no longer in visible DOM
+        if (!parent || !document.body.contains(node)) continue
+        normalizeElement(node)
+        if (++counter > 10) {
+          return setTimeout(continuation, 0)
+        }
+      }
+    }
+    window.requestAnimationFrame(continuation)
+  }
+
+  init()
+}(window.ipfsCompanionNormalizedUnhandledProtocols))

--- a/add-on/src/lib/normalizeLinksWithUnhandledProtocols.js
+++ b/add-on/src/lib/normalizeLinksWithUnhandledProtocols.js
@@ -79,7 +79,7 @@
       while ((node = xpathResult.snapshotItem(i++))) {
         const parent = node.parentNode
         // Skip if no longer in visible DOM
-        if (!parent || !document.body.contains(node)) continue
+        if (!parent || !root.contains(node)) continue
         normalizeElement(node)
         if (++counter > 10) {
           return setTimeout(continuation, 0)

--- a/add-on/src/options/options.html
+++ b/add-on/src/options/options.html
@@ -82,8 +82,11 @@
         box-shadow: 0 0 5px #5FCBCF;
       }
       input:invalid {
-        border: 1px solid #933E98;
-        box-shadow: 0 0 5px #CB5FCF;
+        border: 1px solid red !important;
+        background-color: #FFF0F0;
+        box-shadow: 0 0 5px red !important;
+        color: red;
+        transition: box-shadow 0.3s;
       }
     </style>
     <script src="../lib/npm/browser-polyfill.min.js"></script>
@@ -173,7 +176,7 @@
           <label for="catchUnhandledProtocols">
             <dl>
               <dt>Catch Unhandled IPFS Protocols</dt>
-              <dd>Enables support for <code>ipfs://$cid</code>, <code>ipns://$peerid</code> and <code>dweb:/ipfs/$cid</code> by catching and normalizing requests done with unhandled protocols</dd>
+              <dd>Enables support for <code>ipfs://$cid</code>, <code>ipns://$peerid</code> and <code>dweb:/ipfs/$cid</code> by normalizing links and requests done with unhandled protocols</dd>
             </dl>
           </label>
           <input type="checkbox" id="catchUnhandledProtocols" />

--- a/add-on/src/options/options.js
+++ b/add-on/src/options/options.js
@@ -4,7 +4,7 @@
 
 async function saveOption (name) {
   const element = document.querySelector(`#${name}`)
-  if (!element.checkValidity()) {
+  if (!element.reportValidity()) {
     console.warn('[ipfs-companion] Invalid value for option: ' + name)
     return
   }


### PR DESCRIPTION
This PR implements #286.

Content script detects IPFS-related protocols in `href` and `src` attributes of Elements such as `<a>` or `<img>` and replaces them with URL at the user-specified public HTTP gateway.  
If IPFS API is online, HTTP request will be redirected to custom gateway.

This normalization logic is enabled by "Catch Unhandled IPFS Protocols" experiment.