### PR TITLE
Adds firefox development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,26 @@ For historical background on the rewrite see [Issue #20: Move to WebExtensions](
 
 Install the latest signed release from [Chrome Web Store](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch).
 
-### Other Browsers Supporting WebExtensions API
+### Development or other Browsers Supporting WebExtensions API
 
 Try manual installation:
 
 1. Download Sources
 2. Build it:
 
-  ```bash
-  npm install
-  npm run build
-  ```
+    ```bash
+    npm install
+    npm run build
+    ```
 
-3. Load it into browser (eg. open up `chrome://extensions` in Chromium-based browser, enable "Developer mode", click "Load unpacked extension..." and point it at `add-on/manifest.json`)
-
+3. Load it into browser:
+    * Chromium-based
+        1. Enter `chrome://extensions` in the URL bar
+        2. Enable "Developer mode"
+        3. Click "Load unpacked extension..." and point it at `add-on/manifest.json`
+    * Firefox
+        1. Enter `about:debugging` in the URL bar
+        2. Click "Load Temporary Add-on" and point it at `add-on/manifest.json`
 
 ### TROUBLESHOOTING
 
@@ -141,4 +147,3 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 [is-ipfs](https://github.com/xicombd/is-ipfs), [js-multihash](https://github.com/jbenet/js-multihash) and other NPM dependencies are under MIT license, unless stated otherwise.
 
 The add-on itself is released under [CC0](LICENSE): to the extent possible under law, the author has waived all copyright and related or neighboring rights to this work, effectively placing it in the public domain.
-

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 - [Background](#background)
 - [Features](#features)
 - [Install](#install)
-- [Troubleshooting](#troubleshooting)
 - [Contribute](#contribute)
+- [Troubleshooting](#troubleshooting)
 - [License](#license)
 
 ## Background
@@ -110,6 +110,14 @@ Try manual installation:
         1. Enter `about:debugging` in the URL bar
         2. Click "Load Temporary Add-on" and point it at `add-on/manifest.json`
 
+
+
+## Contribute
+
+If you want to help in developing this extension, please see [CONTRIBUTING](CONTRIBUTING.md) page :sparkles:
+
+This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
 ### TROUBLESHOOTING
 
 #### Upload via Right-Click Does Not Work in Firefox
@@ -133,12 +141,6 @@ Deny
 ```
 
 Feel free to modify it, but get familiar with [ABE rule syntax](https://noscript.net/abe/abe_rules.pdf) first.
-
-## Contribute
-
-Please see [CONTRIBUTING](CONTRIBUTING.md) page :sparkles:
-
-This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 ## License
 


### PR DESCRIPTION
This just adds instructions for installing an "unpacked" extension in Firefox (wisdom gleaned from [this article](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)), and makes it obvious that this is the way you'd also do development.

Can anyone help with these questions?:

1. ~~Is `npm run build` necessary in this context?~~ YES - for copy npm deps into lib
2. I've just read the `CONTRIBUTING.md` and it says use `npm start` to get in installed on firefox - is that still the recommended way?
3. Is it usual for dev instructions be in `CONTRIBUTING.md`? I didn't immediately think to look there...should they be in the `README.md` or at least linked to, from the `README.md`?

