### PR TITLE
Fallback to opening options page manually in brave

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -206,7 +206,7 @@ try {
     onclick: copyAddressAtPublicGw
   })
 } catch (err) {
-  console.error('Error creating contextMenus', err)
+  console.log('[ipfs-companion] Error creating contextMenus', err)
 }
 
 function inFirefox () {
@@ -378,7 +378,7 @@ async function updateContextMenus (changedTabId) {
       }
     }
   } catch (err) {
-    console.error('Error updating context menus', err)
+    console.log('[ipfs-companion] Error updating context menus', err)
   }
 }
 

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -182,28 +182,32 @@ const contextMenuUploadToIpfs = 'contextMenu_UploadToIpfs'
 const contextMenuCopyIpfsAddress = 'panelCopy_currentIpfsAddress'
 const contextMenuCopyPublicGwUrl = 'panel_copyCurrentPublicGwUrl'
 
-browser.contextMenus.create({
-  id: contextMenuUploadToIpfs,
-  title: browser.i18n.getMessage(contextMenuUploadToIpfs),
-  contexts: ['image', 'video', 'audio'],
-  documentUrlPatterns: ['<all_urls>'],
-  enabled: false,
-  onclick: addFromURL
-})
-browser.contextMenus.create({
-  id: contextMenuCopyIpfsAddress,
-  title: browser.i18n.getMessage(contextMenuCopyIpfsAddress),
-  contexts: ['page', 'image', 'video', 'audio', 'link'],
-  documentUrlPatterns: ['*://*/ipfs/*', '*://*/ipns/*'],
-  onclick: copyCanonicalAddress
-})
-browser.contextMenus.create({
-  id: contextMenuCopyPublicGwUrl,
-  title: browser.i18n.getMessage(contextMenuCopyPublicGwUrl),
-  contexts: ['page', 'image', 'video', 'audio', 'link'],
-  documentUrlPatterns: ['*://*/ipfs/*', '*://*/ipns/*'],
-  onclick: copyAddressAtPublicGw
-})
+try {
+  browser.contextMenus.create({
+    id: contextMenuUploadToIpfs,
+    title: browser.i18n.getMessage(contextMenuUploadToIpfs),
+    contexts: ['image', 'video', 'audio'],
+    documentUrlPatterns: ['<all_urls>'],
+    enabled: false,
+    onclick: addFromURL
+  })
+  browser.contextMenus.create({
+    id: contextMenuCopyIpfsAddress,
+    title: browser.i18n.getMessage(contextMenuCopyIpfsAddress),
+    contexts: ['page', 'image', 'video', 'audio', 'link'],
+    documentUrlPatterns: ['*://*/ipfs/*', '*://*/ipns/*'],
+    onclick: copyCanonicalAddress
+  })
+  browser.contextMenus.create({
+    id: contextMenuCopyPublicGwUrl,
+    title: browser.i18n.getMessage(contextMenuCopyPublicGwUrl),
+    contexts: ['page', 'image', 'video', 'audio', 'link'],
+    documentUrlPatterns: ['*://*/ipfs/*', '*://*/ipns/*'],
+    onclick: copyAddressAtPublicGw
+  })
+} catch (err) {
+  console.error('Error creating contextMenus', err)
+}
 
 function inFirefox () {
   return !!navigator.userAgent.match('Firefox')
@@ -362,15 +366,19 @@ async function copyTextToClipboard (copyText) {
 }
 
 async function updateContextMenus (changedTabId) {
-  await browser.contextMenus.update(contextMenuUploadToIpfs, {enabled: state.peerCount > 0})
-  if (changedTabId) {
-    // recalculate tab-dependant menu items
-    const currentTab = await browser.tabs.query({active: true, currentWindow: true}).then(tabs => tabs[0])
-    if (currentTab && currentTab.id === changedTabId) {
-      const ipfsContext = isIpfsPageActionsContext(currentTab.url)
-      browser.contextMenus.update(contextMenuCopyIpfsAddress, {enabled: ipfsContext})
-      browser.contextMenus.update(contextMenuCopyPublicGwUrl, {enabled: ipfsContext})
+  try {
+    await browser.contextMenus.update(contextMenuUploadToIpfs, {enabled: state.peerCount > 0})
+    if (changedTabId) {
+      // recalculate tab-dependant menu items
+      const currentTab = await browser.tabs.query({active: true, currentWindow: true}).then(tabs => tabs[0])
+      if (currentTab && currentTab.id === changedTabId) {
+        const ipfsContext = isIpfsPageActionsContext(currentTab.url)
+        browser.contextMenus.update(contextMenuCopyIpfsAddress, {enabled: ipfsContext})
+        browser.contextMenus.update(contextMenuCopyPublicGwUrl, {enabled: ipfsContext})
+      }
     }
+  } catch (err) {
+    console.error('Error updating context menus', err)
   }
 }
 

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -110,7 +110,13 @@ module.exports = (state, emitter) => {
   })
 
   emitter.on('openPrefs', () => {
-    browser.runtime.openOptionsPage().then(() => window.close())
+    browser.runtime.openOptionsPage()
+      .then(() => window.close())
+      .catch((err) => {
+        console.error('runtime.openOptionsPage() failed, opening options page in tab instead.', err)
+        // brave: fallback to opening options page as a tab.
+        browser.tabs.create({ url: browser.extension.getURL('dist/options/options.html') })
+      })
   })
 
   emitter.on('toggleRedirect', async () => {


### PR DESCRIPTION
In brave the `runtime.openOptionsPage()` call is failing, so the user can't update their prefs.

See: https://github.com/brave/browser-laptop/issues/7812

This PR adds a fallback to opening the options page as a browser tab if the `runtime.openOptionsPage()` throws.

![screenshot 2017-11-17 16 13 59](https://user-images.githubusercontent.com/58871/32956983-6119abf4-cbb2-11e7-8aa8-0fdf063aa615.png)

Also, we add try/catch around calls the following _currently_ unsupported apis
- `contextMenus.create`
- `contextMenus.update`

In the meantime I'll [follow up with brave](https://github.com/brave/browser-laptop/issues/9556#issuecomment-345229249) to see what we need to do to make them available.

WIP on #312 