### PR TITLE
Remove private fields from bundled package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "babel-preset-es2017": "6.24.1",
     "browserify": "14.5.0",
-    "browserify-package-json": "^1.0.1",
+    "browserify-package-json": "1.0.1",
     "chai": "4.1.2",
     "cross-env": "5.1.1",
     "factor-bundle": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:copy": "run-s build:copy:*",
     "build:copy:src": "shx mkdir -p add-on/dist && shx cp -R add-on/src/* add-on/dist",
     "build:copy:wx-polyfill-lib": "shx cp node_modules/webextension-polyfill/dist/browser-polyfill.min.js add-on/dist/lib/browser-polyfill.min.js",
-    "build:js": "browserify add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js",
+    "build:js": "browserify -t [ browserify-package-json --global ] add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js",
     "build:bundle-extension": "web-ext build -s add-on/ -i src/ -a build/",
     "watch": "run-p watch:*",
     "watch:js": "watchify add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js -v",
@@ -35,6 +35,7 @@
   "devDependencies": {
     "babel-preset-es2017": "6.24.1",
     "browserify": "14.5.0",
+    "browserify-package-json": "^1.0.1",
     "chai": "4.1.2",
     "cross-env": "5.1.1",
     "factor-bundle": "2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,6 +813,10 @@ browserify-des@^1.0.0:
     des.js "^1.0.0"
     inherits "^2.0.1"
 
+browserify-package-json@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-package-json/-/browserify-package-json-1.0.1.tgz#98dde8aa5c561fd6d3fe49bbaa102b74b396fdea"
+
 browserify-rsa@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,7 +813,7 @@ browserify-des@^1.0.0:
     des.js "^1.0.0"
     inherits "^2.0.1"
 
-browserify-package-json@^1.0.1:
+browserify-package-json@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/browserify-package-json/-/browserify-package-json-1.0.1.tgz#98dde8aa5c561fd6d3fe49bbaa102b74b396fdea"
 


### PR DESCRIPTION
Fixes the issue of private, build machine specific fields from package.json appearing in the bundle, by adding https://github.com/fanatid/browserify-package-json as a global browserify transform 

After this change the diff is clean between a local build via `npx yarn@1.2.1 && npx yarn@1.2.1 build` and a `docker-build` run.

See: https://github.com/ipfs/ipfs-companion/pull/311#issuecomment-345771694