### PR TITLE
fix: reduce menu render jank

### DIFF
--- a/add-on/src/popup/browser-action/gateway-status.js
+++ b/add-on/src/popup/browser-action/gateway-status.js
@@ -16,7 +16,7 @@ module.exports = function gatewayStatus ({
 }) {
   const api = ipfsNodeType === 'embedded' ? 'js-ipfs' : ipfsApiUrl
   return html`
-    <ul class="list mv3 ph3">
+    <ul class="list mv3 ph3 bg-white black">
       <li class="flex mb2">
         <span class="w-40 f7 ttu">${browser.i18n.getMessage('panel_statusGatewayAddress')}</span>
         <code class="w-60 f7 tr">${gatewayAddress == null ? 'unknown' : gatewayAddress}</code>

--- a/add-on/src/popup/browser-action/index.html
+++ b/add-on/src/popup/browser-action/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width" />
   </head>
-  <body style="width: 320px; overflow: hidden;">
+  <body style="width: 320px; overflow: hidden; background: white;">
     <div id="root"></div>
     <script src="../../ipfs-companion-common.js"></script>
     <script src="browser-action.js"></script>

--- a/add-on/src/popup/browser-action/index.html
+++ b/add-on/src/popup/browser-action/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width" />
   </head>
-  <body>
+  <body style="width: 320px; overflow: hidden;">
     <div id="root"></div>
     <script src="../../ipfs-companion-common.js"></script>
     <script src="browser-action.js"></script>

--- a/add-on/src/popup/browser-action/nav-item.js
+++ b/add-on/src/popup/browser-action/nav-item.js
@@ -4,7 +4,7 @@
 const html = require('choo/html')
 
 function navItem ({ icon, text, bold, disabled, onClick }) {
-  let className = 'button-reset db w-100 bg-white bg-near-white--hover b--none outline-0--focus pointer pv2 ph3 f5 tl'
+  let className = 'button-reset db w-100 black bg-white bg-near-white--hover b--none outline-0--focus pointer pv2 ph3 f5 tl'
   if (bold) className += ' b'
 
   return html`

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -30,7 +30,7 @@ module.exports = function browserActionPage (state, emit) {
   const gwStatusProps = Object.assign({}, state)
 
   return html`
-    <div class="helvetica" style="min-width: 320px">
+    <div class="helvetica">
       ${header(headerProps)}
       ${contextActions(contextActionsProps)}
       ${operations(opsProps)}


### PR DESCRIPTION
Browser menu rendering in brave is super janky. This PR in-lines width and overflow styles to the body element of the menu page so the browser has a clue as early as possible how wide the menu will be. Brave renders a scroll bar on the menu by default, so we disable that too.

The height of our menu changes, which can also causes some render jank, so it'd be worth considering marking menu items as visually disabled rather then pulling them out of the menu when not available.

Also adds explicit color styles to hopefully fix #329 though I've not been able to test it.