### PR TITLE
fix: onboarding flow in Brave

### DIFF
--- a/add-on/src/lib/ipfs-client/brave.js
+++ b/add-on/src/lib/ipfs-client/brave.js
@@ -40,8 +40,8 @@ exports.destroy = async function (browser) {
 // ipfs:// URI that will be used for triggering the "Enable IPFS" dropbar in Brave
 // Here we use inlined empty byte array, which resolves instantly and does not
 // introduce any delay in UI.
-const braveIpfsUriTrigger = 'ipfs://bafkqaaa/'
-const braveGatewayUrlTrigger = 'https://bafkqaaa.ipfs.dweb.link/'
+const braveIpfsUriTrigger = 'ipfs://bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss/'
+const braveGatewayUrlTrigger = 'https://bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss.ipfs.dweb.link/'
 
 // Settings screen in Brave where user can manage IPFS support
 const braveSettingsPage = 'brave://settings/extensions'
@@ -245,10 +245,10 @@ async function activationUiCleanup (browser) {
   try {
     // after useBraveEndpoint we can start polling for gateway to become online
     const { customGatewayUrl: braveGwUrl } = await browser.storage.local.get('customGatewayUrl')
-    // wait 1m for gateway to be online (bafkqaaa)
+    // wait 1m for gateway to be online (bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss)
     await waitFor(async () => {
       try {
-        return await fetch(`${braveGwUrl}/ipfs/bafkqaaa`).then(response => response.ok)
+        return await fetch(`${braveGwUrl}/ipfs/bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss`).then(response => response.ok)
       } catch (_) {
         return false
       }

--- a/test/functional/lib/ipfs-request-workarounds.test.js
+++ b/test/functional/lib/ipfs-request-workarounds.test.js
@@ -303,7 +303,7 @@ describe('modifyRequest processing', function () {
     it('should force native URI in address bar via tabs.update API', async function () {
       const httpDNSLinkUrl = 'https://example.com/ipns/docs.ipfs.io/some/path?query=val'
       const nativeDNSLinkUri = 'ipns://docs.ipfs.io/some/path?query=val'
-      spoofDnsTxtRecord('docs.ipfs.io', dnslinkResolver, '/ipfs/bafkqaaa')
+      spoofDnsTxtRecord('docs.ipfs.io', dnslinkResolver, '/ipfs/bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss')
       state.ipfsNodeType = braveNodeType
       // ensure clean modifyRequest
       runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
@@ -330,7 +330,7 @@ describe('modifyRequest processing', function () {
       const request = {
         method: 'GET',
         type: 'image',
-        url: 'https://ipfs.io/ipfs/bafkqaaa',
+        url: 'https://ipfs.io/ipfs/bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss',
         initiator: 'https://some-website.example.com' // Brave (built on Chromium)
       }
       expect(modifyRequest.onBeforeRequest(request))
@@ -339,7 +339,7 @@ describe('modifyRequest processing', function () {
     it('should be left untouched if subresource (would be blocked by Brave Shields)', function () {
       runtime.isFirefox = false
       runtime.brave = { thisIsFakeBraveRuntime: true }
-      const cid = 'bafkqaaa'
+      const cid = 'bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss'
       const request = {
         method: 'GET',
         type: 'main_frame',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,15 +3016,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.1.0.tgz#27dc176173725fb0adf8a48b647f4d7871944d78"
   integrity sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==
 
-caniuse-lite@^1.0.30001135:
-  version "1.0.30001151"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz#1ddfde5e6fff02aad7940b4edb7d3ac76b0cb00b"
-  integrity sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001198"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz#ed2d9b5f060322ba2efa42afdc56dee3255473f4"
-  integrity sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==
+caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001181:
+  version "1.0.30001238"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz"
+  integrity sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This replaces `bafkqaaa` with `bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss` to ensure gateway response in go-ipfs 0.9 does not error (+  provide human-readable response in case someone copies it from address bar)

Fixes https://github.com/brave/brave-browser/issues/16671