### PR TITLE
docs: fix community CONTRIBUTING.md links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,5 +37,5 @@ If you want to downoad translations from Transifex and run them locally, make su
 ## How to Help with Things Beyond Browser Extension?
 
 - https://github.com/ipfs/in-web-browsers
-- https://github.com/ipfs/community/blob/master/contributing.md  
-  [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+- https://github.com/ipfs/community/blob/master/CONTRIBUTING.md  
+  [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
current contributing.md link returns 404.
This link is also broken in some other projects of this organization. All instances can be checked using https://github.com/search?q=org%3Aipfs+%22community%2Fblob%2Fmaster%2Fcontributing.md%22&type=Code&ref=advsearch&l=&l=

Unfortunately github doesn't offer case-sensitive search so we can't filter exact number of instances.