### PR TITLE
fix: truncate no. of peers to unit of "k" when > 999

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -507,13 +507,13 @@ module.exports = async function init () {
     }
 
     let badgeText, badgeColor, badgeIcon
-    
+
     badgeText = ''
     if (state.peerCount > 0) {
       // All is good (online with peers)
       badgeColor = '#418B8E'
       badgeIcon = '/icons/ipfs-logo-on.svg'
-      
+
       // prevent text overflow when peer count has more than 3 digits
       badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount / 1000).toString() + 'k') : state.peerCount.toString()
     } else if (state.peerCount === 0) {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -507,12 +507,13 @@ module.exports = async function init () {
     }
 
     let badgeText, badgeColor, badgeIcon
-    // prevent text overflow when peer count has more than 3 digits
-    badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount / 1000).toString() + 'k') : state.peerCount.toString()
     if (state.peerCount > 0) {
       // All is good (online with peers)
       badgeColor = '#418B8E'
       badgeIcon = '/icons/ipfs-logo-on.svg'
+      
+      // prevent text overflow when peer count has more than 3 digits
+      badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount / 1000).toString() + 'k') : state.peerCount.toString()
     } else if (state.peerCount === 0) {
       // API is online but no peers
       badgeColor = 'red'

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -508,7 +508,7 @@ module.exports = async function init () {
 
     let badgeText, badgeColor, badgeIcon
     // prevent text overflow when peer count has more than 3 digits
-    badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount/1000).toFixed(0) + "k") : state.peerCount.toString();
+    badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount / 1000).toString() + 'k') : state.peerCount.toString()
     if (state.peerCount > 0) {
       // All is good (online with peers)
       badgeColor = '#418B8E'

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -507,7 +507,8 @@ module.exports = async function init () {
     }
 
     let badgeText, badgeColor, badgeIcon
-    badgeText = state.peerCount.toString()
+    // prevent text overflow when peer count has more than 3 digits
+    badgeText = (state.peerCount > 999) ? (Math.floor(state.peerCount/1000).toFixed(0) + "k") : state.peerCount.toString();
     if (state.peerCount > 0) {
       // All is good (online with peers)
       badgeColor = '#418B8E'

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -507,6 +507,8 @@ module.exports = async function init () {
     }
 
     let badgeText, badgeColor, badgeIcon
+    
+    badgeText = ''
     if (state.peerCount > 0) {
       // All is good (online with peers)
       badgeColor = '#418B8E'
@@ -520,7 +522,6 @@ module.exports = async function init () {
       badgeIcon = '/icons/ipfs-logo-on.svg'
     } else {
       // API is offline
-      badgeText = ''
       badgeColor = '#8C8C8C'
       badgeIcon = '/icons/ipfs-logo-off.svg'
     }


### PR DESCRIPTION
#1017 

**About**
The issue opener found out that when number of peers is 1000 or above, the last digit might be partially invisible and cause confusion due to the badge's max width. 

The core team replied to the issue suggesting to truncate it in the format of "1k", "2k". So I implemented the approach and made this PR.

**Original UI**

<img width="32" alt="128388115-9fcf5a09-6e82-4234-9d7d-b9225213ccad" src="https://user-images.githubusercontent.com/22004238/154693084-c3e110a3-7db4-42ba-ba5f-37d0afffdb01.png">

**Committed UI Change**

- [X] truncate no. of peers to unit of "k" when > 999 (e.g. the count is 2352 in this case)

<img width="81" alt="Screenshot 2022-02-18 at 11 44 58 AM" src="https://user-images.githubusercontent.com/22004238/154693528-f62f4b60-7c24-4509-a017-3e754e62ca6a.png">


Show full number when < 999

<img width="80" alt="Screenshot 2022-02-18 at 11 46 59 AM" src="https://user-images.githubusercontent.com/22004238/154693541-015f489d-17b9-4a05-ab41-3af979c26f98.png">


This is my first PR, please let me know if I could do it better, looking forward to help with other tasks of this repo and IPFS!

