### PR TITLE
feat: save "Path to store imported files" preference from import page

### DIFF
--- a/add-on/src/popup/quick-import.js
+++ b/add-on/src/popup/quick-import.js
@@ -61,6 +61,11 @@ function quickImportStore (state, emitter) {
 
   emitter.on('fileInputChange', event => processFiles(state, emitter, event.target.files))
 
+  // update companion preference
+  emitter.on('optionChange', ({ key, value }) => {
+    browser.storage.local.set({ [key]: value })
+  })
+
   // drag & drop anywhere
   drop(document.body, files => processFiles(state, emitter, files))
 }
@@ -138,6 +143,10 @@ async function processFiles (state, emitter, files) {
     copyShareLink(results)
     preloadFilesAtPublicGateway(results)
 
+    // update preferred import dir if user specified one while importing
+    if (state.userChangedImportDir) {
+      emitter.emit('optionChange', { key: 'importDir', value: state.importDir })
+    }
     // present result to the user using the beast available way
     if (!state.openViaWebUI || state.ipfsNodeType.startsWith('embedded')) {
       await openFilesAtGateway(importDir)


### PR DESCRIPTION
#1028 

**About** 
When a user specified a custom path to store imported file while importing with the quick import popup, the path will be saved to preference and will be automatically applied next time.

<img width="808" alt="Screenshot 2022-02-26 at 5 59 32 PM" src="https://user-images.githubusercontent.com/22004238/155839222-a84b7307-313d-41e7-b802-100aae6dbc44.png">

<img width="1289" alt="Screenshot 2022-02-26 at 6 00 15 PM" src="https://user-images.githubusercontent.com/22004238/155839226-ef1534e5-5c92-4175-b879-fd6fdda308b5.png">


**Remarks**
The issue opener suggests to save path to preference as long as the textbox lost focus.

I have concern that, sometimes the path might be incomplete / not valid when user lost focus of the textbox.

So for the code I commit, I save the path to preference after a successful import to make sure the path is completed already and is valid

Please let me know if you would like me to do any other approaches.

