### PR TITLE
fix(ci): windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 14
 
       - name: Restore .cache
         uses: actions/cache@v2
@@ -38,6 +38,10 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Microsoft Build Tools
+        if: runner.os == 'Windows'
+        run: npm install --global windows-build-tools
 
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -74,4 +78,3 @@ jobs:
 
       - name: Show Cache
         run: du -h ${{ github.workspace }}/.cache/* || true
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Microsoft Build Tools
         if: runner.os == 'Windows'
-        run: npm install --global windows-build-tools
+        run: npm install --global --production windows-build-tools --vs2015
 
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Looks like builds are broken on `windows-latest`: https://github.com/ipfs/ipfs-companion/actions/workflows/ci.yml

The reported error: `gyp ERR! stack Error: Could not find any Visual Studio installation to use`

I could not test this as I don't have perms to run CI nor do I have access to a windows machine atm, but there seems like two ways to fix this:
- We can either move to node-v16 which ships with build tools.
- Or add this dependency based on https://github.com/felixrieseberg/windows-build-tools

the github `actions/setup-node@v1` is also 2 major versions behind, so should be upgraded as well, but I'm unsure of the breaking API changes between the two.

🤞🏽 this should fix the broken builds in theory.