### PR TITLE
fix(test): exit mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "watch:js": "run-p watch:js:*",
     "watch:js:webpack": "webpack --watch --mode development --devtool inline-source-map  --config ./webpack.config.js",
     "test": "run-s test:*",
-    "test:functional": "c8 mocha --timeout 5000 --require ignore-styles \"test/functional/**/*.test.js\"",
+    "test:functional": "c8 mocha --timeout 5000 --exit --require ignore-styles \"test/functional/**/*.test.js\"",
     "lint": "run-s lint:*",
     "lint:standard": "standard -v \"*.js\" \"add-on/src/**/*.js\" \"test/**/*.js\" \"scripts/**/*.js\"",
     "lint:web-ext": "web-ext lint",


### PR DESCRIPTION
This PR fixes mocha hangs.

Without this, tests sometimes hang due to racy tests or missing orchestration cleanup.
`npm test` should finish <3s, then c8 takes a few additional seconds, but  sometimes it hangs forever and leads to timeout:
- https://github.com/ipfs/ipfs-companion/actions/runs/3541084119/jobs/5944912207#step:11:529