### PR TITLE
fix: allowing CSP eval to not throw errors

### DIFF
--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -25,6 +25,7 @@
     "webRequest",
     "webRequestBlocking"
   ],
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; frame-src 'self';",
   "content_scripts": [ ],
   "protocol_handlers": [
     {

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -6,7 +6,7 @@ set -e
 MANIFEST=add-on/manifest.common.json
 
 # restore original in case it was modified manually
-test -d .git && git checkout -- $MANIFEST
+# test -d .git && git checkout -- $MANIFEST
 
 # skip all manifest mutations when building for stable channel
 if [ "$RELEASE_CHANNEL" = "stable" ]; then


### PR DESCRIPTION
Allowing `unsafe-eval` for firefox