### PR TITLE
chore: add sourceMaps to dev-builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ci:lint": "npm run lint",
     "beta-build": "docker rmi -f ipfs-companion-beta-build && docker build -t ipfs-companion-beta-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm --net=host -e RELEASE_CHANNEL=beta -v $(pwd)/build:/home/node/app/build ipfs-companion-beta-build npm run ci:build",
     "release-build": "docker rmi -f ipfs-companion-release-build && docker build -t ipfs-companion-release-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm --net=host -e RELEASE_CHANNEL=stable -v $(pwd)/build:/home/node/app/build ipfs-companion-release-build npm run ci:build",
-    "dev-build": "npm ci && npm run build",
+    "dev-build": "npm ci && cross-env NODE_ENV='development' npm run build",
     "yarn-build": "npm run dev-build",
     "compose:e2e:prepare": "docker compose --file docker-compose.e2e.yml pull && docker compose --file docker-compose.e2e.yml build",
     "compose:e2e:up": "docker compose --file docker-compose.e2e.yml up --remove-orphans --detach kubo chromium firefox",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,12 @@ const require = createRequire(import.meta.url)
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// common configuration shared by all targets
+const devBuild = process.env.NODE_ENV === 'development'
+
+/**
+ * common configuration shared by all targets
+ * @type {import('webpack').Configuration}
+ */
 const commonConfig = {
   target: 'web',
   bail: true,
@@ -110,7 +115,14 @@ const commonConfig = {
   }
 }
 
-// background page bundle (with heavy dependencies)
+if (devBuild) {
+  commonConfig.devtool = 'source-map'
+}
+
+/**
+ * background page bundle (with heavy dependencies)
+ * @type {import('webpack').Configuration}
+ */
 const bgConfig = merge(commonConfig, {
   name: 'background',
   entry: {
@@ -134,7 +146,10 @@ const bgConfig = merge(commonConfig, {
   }
 })
 
-// user interface pages with shared common libraries
+/**
+ * user interface pages with shared common libraries
+ * @type {import('webpack').Configuration}
+ */
 const uiConfig = merge(commonConfig, {
   name: 'ui',
   entry: {
@@ -161,7 +176,10 @@ const uiConfig = merge(commonConfig, {
   }
 })
 
-// content scripts injected into tabs
+/**
+ * content scripts injected into tabs
+ * @type {import('webpack').Configuration}
+ */
 const contentScriptsConfig = merge(commonConfig, {
   name: 'contentScripts',
   entry: {


### PR DESCRIPTION
* `npm run dev-build` produces sourceMaps.
* `npm run build` does not produce sourceMaps.
