### PR TITLE
fix(mv3): FF Browser Action

### DIFF
--- a/add-on/src/lib/redirect-handler/blockOrObserve.ts
+++ b/add-on/src/lib/redirect-handler/blockOrObserve.ts
@@ -181,6 +181,9 @@ function validateIfRuleChanged (rule: browser.DeclarativeNetRequest.Rule): boole
  * Clean up all the rules, when extension is disabled.
  */
 export async function cleanupRules (resetInMemory: boolean = false): Promise<void> {
+  if (supportsBlock()) {
+    return
+  }
   const existingRules = await browser.declarativeNetRequest.getDynamicRules()
   const existingRulesIds = existingRules.map(({ id }): number => id)
   await browser.declarativeNetRequest.updateDynamicRules({ addRules: [], removeRuleIds: existingRulesIds })


### PR DESCRIPTION
Closes: #1274 

Broken in: #1266

Cause: MV3 APIs accessed in MV2 Scope

Test:
- there is no easy/automated way to test this, I spent some time looking into writing an e2e test, but nope.