### PR TITLE
feat: show full rpc backend version

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -35,13 +35,9 @@
     "message": "The URL of your local Kubo RPC",
     "description": "A label in Node status section of Browser Action pop-up (panel_statusApiAddressTitle)"
   },
-  "panel_statusGatewayVersion": {
-    "message": "version",
-    "description": "A label in Node status section of Browser Action pop-up (panel_statusGatewayVersion)"
-  },
-  "panel_statusGatewayVersionTitle": {
-    "message": "The version of IPFS your local node is using",
-    "description": "A label in Node status section of Browser Action pop-up (panel_statusGatewayVersionTitle)"
+  "panel_kuboRpcBackendVersionTitle": {
+    "message": "The version of IPFS backend this extension talks to over Kubo RPC API",
+    "description": "A label in Node status section of Browser Action pop-up (panel_kuboRpcBackendVersionTitle)"
   },
   "panel_statusSwarmPeers": {
     "message": "Peers",

--- a/add-on/src/popup/browser-action/gateway-status.js
+++ b/add-on/src/popup/browser-action/gateway-status.js
@@ -19,7 +19,7 @@ function statusEntry ({ label, labelLegend, value, check, itemClass = '', valueC
 
 export default function gatewayStatus ({
   gatewayAddress,
-  gatewayVersion,
+  kuboRpcBackendVersion,
   ipfsApiUrl,
   swarmPeers
 }) {
@@ -42,7 +42,7 @@ export default function gatewayStatus ({
       label: 'panel_statusApiAddress',
       labelLegend: 'panel_statusApiAddressTitle',
       value: api,
-      check: gatewayVersion
+      check: kuboRpcBackendVersion
     })}
     </ul>
   `

--- a/add-on/src/popup/browser-action/ipfs-version.js
+++ b/add-on/src/popup/browser-action/ipfs-version.js
@@ -11,20 +11,19 @@ function statusEntry ({ label, labelLegend, title, value, check, valueClass = ''
   value = value || value === 0 ? value : offline
   return html`
       <div title="${labelLegend}" class="ma0 pa0" style="line-height: 0.25">
-        <span class="f7 tr monospace force-select-all ${valueClass}" title="${title}">${value.substring(0, 13)}</span>
+        <span class="f7 tr monospace force-select-all ${valueClass}" title="${title}">${value.substring(0, 18)}</span>
       </div>
     `
 }
 
 export default function ipfsVersion ({
-  gatewayVersion
+  kuboRpcBackendVersion
 }) {
   return html`
   ${statusEntry({
-    label: 'panel_statusGatewayVersion',
-    title: browser.i18n.getMessage('panel_statusGatewayVersionTitle'),
-    value: gatewayVersion,
-    check: gatewayVersion
+    title: browser.i18n.getMessage('panel_kuboRpcBackendVersionTitle'),
+    value: kuboRpcBackendVersion,
+    check: kuboRpcBackendVersion
   })}
   `
 }

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -27,7 +27,7 @@ export default (state, emitter) => {
     publicSubdomainGatewayUrl: null,
     gatewayAddress: null,
     swarmPeers: null,
-    gatewayVersion: null,
+    kuboRpcBackendVersion: null,
     isApiAvailable: false,
     // isRedirectContext
     currentTab: null,
@@ -215,7 +215,7 @@ export default (state, emitter) => {
       if (!state.active) {
         state.gatewayAddress = state.pubGwURLString
         state.ipfsApiUrl = null
-        state.gatewayVersion = null
+        state.kuboRpcBackendVersion = null
         state.swarmPeers = null
         state.isIpfsOnline = false
       }
@@ -241,13 +241,13 @@ export default (state, emitter) => {
       state.isApiAvailable = state.active && !browser.extension.inIncognitoContext // https://github.com/ipfs-shipyard/ipfs-companion/issues/243
       state.swarmPeers = !state.active || status.peerCount === -1 ? null : status.peerCount
       state.isIpfsOnline = state.active && status.peerCount > -1
-      state.gatewayVersion = state.active && status.gatewayVersion ? status.gatewayVersion : null
+      state.kuboRpcBackendVersion = state.active && status.kuboRpcBackendVersion ? status.kuboRpcBackendVersion : null
       state.ipfsApiUrl = state.active ? status.apiURLString : null
     } else {
       state.ipfsNodeType = 'external'
       state.swarmPeers = null
       state.isIpfsOnline = false
-      state.gatewayVersion = null
+      state.kuboRpcBackendVersion = null
       state.isIpfsContext = false
       state.isRedirectContext = false
     }


### PR DESCRIPTION
This PR will try to read version from `ipfs.id` before it falls back to `ipfs.version`.

Rationale: 
- we now have useful AgentVersion returned by 'ipfs id' Kubo RPC command which allows for including suffix (e.g. in brave).
- this makes it more obvious that kubo backend is used, and in which version, and removes perception that kubo version === ipfs version


### Preview


| Before | After |
| ---- | ---- |
| ![2023-09-22_15-21](https://github.com/ipfs/ipfs-companion/assets/157609/4b5492aa-7b0e-4adb-a2b3-12a03a3c4c83)  |  ![2023-09-22_15-22](https://github.com/ipfs/ipfs-companion/assets/157609/fc83bc3d-537d-4235-a632-2d6cea4dfb3f) ![2023-09-22_15-25](https://github.com/ipfs/ipfs-companion/assets/157609/62b2fd51-0789-4c2a-a0d4-16287980ecec) |


