### PR TITLE
fix: ipfs.dns → ipfs.resolve

### DIFF
--- a/add-on/src/lib/precache.js
+++ b/add-on/src/lib/precache.js
@@ -15,7 +15,7 @@ export async function precache (ipfs, state) {
   try {
     let cid, name
     if (state.useLatestWebUI) { // resolve DNSLink
-      cid = await ipfs.dns('webui.ipfs.io', { recursive: true })
+      cid = await ipfs.resolve('/ipns/webui.ipfs.io', { recursive: true })
       name = 'latest webui from DNSLink at webui.ipfs.io'
     } else { // find out safelisted path behind <api-port>/webui
       cid = new URL((await fetch(`${state.apiURLString}webui`)).url).pathname


### PR DESCRIPTION
This PR aims to fix webui preload in Kubo 0.24.

Context: `ipfs.dns` has been deprecated for a while, and the way we use it here got broken in Kubo 0.24: https://github.com/ipfs/kubo/pull/10212