### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       # - action artifacts can be downloaded for 90 days, then are removed by github
       # - binaries in PRs from forks won't be signed
       - name: Attach produced packages to Github Action
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: built-on-${{ matrix.os }}
           path: build/ipfs_companion*.*


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/