### PR TITLE
chore: update actions/cache from v3.2.4 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
       - name: Restore .cache
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ github.workspace }}/.cache
@@ -50,7 +50,7 @@ jobs:
 
       - name: Restore node_modules
         id: yarn-cache
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package*json', '**/package-lock.json', '**/*config.js', '**/*.patch') }}
@@ -123,7 +123,7 @@ jobs:
           node-version: 18
 
       - name: Restore .cache
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ github.workspace }}/.cache
@@ -134,7 +134,7 @@ jobs:
 
       - name: Restore node_modules
         id: yarn-cache
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package*json', '**/package-lock.json', '**/*config.js', '**/*.patch') }}


### PR DESCRIPTION
This PR updates the deprecated version of actions/cache (v3.2.4) to the latest version (v4) to resolve CI failures in https://github.com/ipfs/ipfs-companion/pull/1328

The error message that prompted this change was:


> Error: This request has been automatically failed because it uses a deprecated version of . Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
> 
> \- https://github.com/ipfs/ipfs-companion/actions/runs/13635460809/job/38113001518?pr=1328