### PR TITLE
fix: skip DNSLink resolution when offline, deduplicate inflights

### DIFF
--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -82,7 +82,7 @@ export default function createDnslinkResolver (getState) {
       }
 
       // Create new lookup promise
-      const lookupPromise = (async () => {
+      const lookupPromise = async () => {
         try {
           log(`dnslink cache miss for '${fqdn}', running DNS TXT lookup`)
           dnslink = await dnslinkResolver.readDnslinkFromTxtRecord(fqdn)
@@ -105,11 +105,11 @@ export default function createDnslinkResolver (getState) {
           // Clean up pending lookup once complete
           pendingLookups.delete(fqdn)
         }
-      })()
+      }
 
       // Store the promise for deduplication
-      pendingLookups.set(fqdn, lookupPromise)
-      return lookupPromise
+      pendingLookups.set(fqdn, lookupPromise())
+      return pendingLookups.get(fqdn)
     },
 
     // runs async lookup in a queue in the background and returns the record

--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -143,7 +143,14 @@ export default function createDnslinkResolver (getState) {
       })
     },
 
-    // low level lookup without cache
+    /**
+     * Low level DNSLink lookup without cache
+     * @param {string} fqdn - Fully qualified domain name to lookup
+     * @returns {Promise<string|false|undefined>}
+     *   - string: valid DNSLink path (e.g., '/ipfs/QmHash')
+     *   - false: no DNSLink found or error occurred
+     *   - undefined: offline/no peers available
+     */
     async readDnslinkFromTxtRecord (fqdn) {
       const state = getState()
 


### PR DESCRIPTION
### fix: remove ipfs.io fallback in DNSLink resolution

- prevent privacy DNS leak by not sending requests to external services
- removed hardcoded fallback to https://ipfs.io/ when offline
- return `undefined` when offline to avoid caching false negatives
- closes https://github.com/ipfs/ipfs-companion/issues/1337

### fix: deduplicate concurrent DNSLink lookups for same domain
- added in-flight request tracking with pendingLookups Map
- prevents multiple simultaneous API calls for the same FQDN
- reduces redundant requests from 2-4 down to 1 per domain