### PR TITLE
fix: manifest v3 offline status detection (#1338)

### DIFF
--- a/add-on/manifest.chromium.json
+++ b/add-on/manifest.chromium.json
@@ -5,6 +5,7 @@
   },
   "permissions": [
     "activeTab",
+    "alarms",
     "clipboardWrite",
     "contextMenus",
     "declarativeNetRequest",

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -15,6 +15,7 @@
     }
   },
   "permissions": [
+    "alarms",
     "idle",
     "tabs",
     "notifications",

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -52,6 +52,7 @@ export default async function init (inQuickImport = false) {
   let ipfsImportHandler
   const idleInSecs = 5 * 60
   const browserActionPortName = 'browser-action-port'
+  const kuboRpcStatusAlarmName = 'kubo-rpc-status'
 
   try {
     log('init')
@@ -138,6 +139,18 @@ export default async function init (inQuickImport = false) {
     }
     browser.runtime.onMessage.addListener(onRuntimeMessage)
     browser.runtime.onConnect.addListener(onRuntimeConnect)
+
+    // Register alarm listener for Manifest V3 compatibility
+    // This ensures API status updates continue even when service worker goes dormant
+    if (browser.alarms) {
+      browser.alarms.onAlarm.addListener((alarm) => {
+        if (alarm.name === kuboRpcStatusAlarmName) {
+          log('Alarm triggered for API status update')
+          runIfNotIdle(apiStatusUpdate)
+        }
+      })
+      log('Registered alarm listener for API status updates')
+    }
 
     if (runtime.hasNativeProtocolHandler) {
       log('native protocol handler support detected, but IPFS handler is not implemented yet :-(')
@@ -453,12 +466,47 @@ export default async function init (inQuickImport = false) {
   // API STATUS UPDATES
   // -------------------------------------------------------------------
   // API is polled for peer count every ipfsApiPollMs
+  // In Manifest V3 (Chromium), service workers go dormant after ~30 seconds of inactivity,
+  // which stops setInterval. To ensure continuous monitoring, we use a hybrid approach:
+  // - For polling < 30s: Use BOTH setInterval (for precise timing) AND alarms (as backup)
+  // - For polling >= 30s: Use ONLY alarms (avoids duplicate timers, more efficient)
+  // Note: Chrome alarms API has a minimum interval of 30 seconds
 
   async function setApiStatusUpdateInterval (ipfsApiPollMs) {
+    // Clear existing interval if present
     if (apiStatusUpdateInterval) {
       clearInterval(apiStatusUpdateInterval)
+      apiStatusUpdateInterval = null
     }
-    apiStatusUpdateInterval = setInterval(() => runIfNotIdle(apiStatusUpdate), ipfsApiPollMs)
+
+    // Clear existing alarm if present
+    if (browser.alarms) {
+      await browser.alarms.clear(kuboRpcStatusAlarmName)
+    }
+
+    // Use alarms API if available (for Manifest V3 compatibility)
+    if (browser.alarms) {
+      // Always create an alarm as backup (minimum 30 seconds)
+      const periodInSeconds = Math.max(30, Math.floor(ipfsApiPollMs / 1000))
+      await browser.alarms.create(kuboRpcStatusAlarmName, {
+        periodInMinutes: periodInSeconds / 60
+      })
+      log(`Created alarm for API status updates every ${periodInSeconds} seconds`)
+
+      // For fast polling (< 30s), also use setInterval for more precise updates
+      // This ensures responsive updates when the service worker is active
+      if (ipfsApiPollMs < 30000) {
+        apiStatusUpdateInterval = setInterval(() => runIfNotIdle(apiStatusUpdate), ipfsApiPollMs)
+        log(`Also using setInterval for fast polling every ${ipfsApiPollMs}ms`)
+      }
+      // For slow polling (>= 30s), rely only on alarms to avoid duplicate timers
+    } else {
+      // Fallback for environments without alarms API
+      apiStatusUpdateInterval = setInterval(() => runIfNotIdle(apiStatusUpdate), ipfsApiPollMs)
+      log(`Using setInterval only (no alarms API available) every ${ipfsApiPollMs}ms`)
+    }
+
+    // Run immediately
     await apiStatusUpdate()
   }
 
@@ -687,6 +735,24 @@ export default async function init (inQuickImport = false) {
         ipfs = null
       }
 
+      // Stop API status updates when extension is disabled
+      if (shouldStopIpfsClient) {
+        log('stopping API status updates (extension disabled)')
+
+        // Stop monitoring first
+        if (apiStatusUpdateInterval) {
+          clearInterval(apiStatusUpdateInterval)
+          apiStatusUpdateInterval = null
+        }
+        if (browser.alarms) {
+          await browser.alarms.clear(kuboRpcStatusAlarmName)
+        }
+
+        // Set offline state and update badge as the final action
+        state.peerCount = offlinePeerCount
+        await updateBrowserActionBadge()
+      }
+
       if (!state.active) return
 
       try {
@@ -701,7 +767,13 @@ export default async function init (inQuickImport = false) {
         )
       }
 
-      apiStatusUpdate()
+      // Restart API status updates when extension is re-enabled
+      if (state.active && ipfs) {
+        log('restarting API status updates (extension enabled)')
+        setApiStatusUpdateInterval(state.ipfsApiPollMs)
+      } else {
+        apiStatusUpdate()
+      }
     }
     if (shouldReloadExtension) {
       log('reloading extension due to config change')
@@ -754,6 +826,11 @@ export default async function init (inQuickImport = false) {
       if (apiStatusUpdateInterval) {
         clearInterval(apiStatusUpdateInterval)
         apiStatusUpdateInterval = null
+      }
+
+      // Clear alarm if present
+      if (browser.alarms) {
+        await browser.alarms.clear(kuboRpcStatusAlarmName)
       }
 
       if (ipfs) {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -31,7 +31,7 @@ export const optionDefaults = Object.freeze({
   customGatewayUrl: 'http://localhost:8080',
   ipfsApiUrl: 'http://127.0.0.1:5001',
   ipfsApiPollMs: 3000,
-  logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*',
+  logNamespaces: 'ipfs-companion*',
   importDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/',
   useLatestWebUI: false,
   dismissedUpdate: null,

--- a/add-on/src/options/forms/api-form.js
+++ b/add-on/src/options/forms/api-form.js
@@ -31,7 +31,7 @@ export default function apiForm ({ ipfsNodeType, ipfsApiUrl, ipfsApiPollMs, auto
             type="url"
             inputmode="url"
             required
-            pattern="^https?://[^/]+/?$"
+            pattern="https?://.+"
             spellcheck="false"
             title="${browser.i18n.getMessage(apiAddresEditable ? 'option_hint_url' : 'option_hint_readonly')}"
             onchange=${onIpfsApiUrlChange}

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -53,7 +53,7 @@ export default function gatewaysForm ({
               type="url"
               inputmode="url"
               required
-              pattern="^https?://[^/]+/?$"
+              pattern="https?://.+"
               spellcheck="false"
               title="${browser.i18n.getMessage('option_hint_url')}"
               onchange=${onPublicGatewayUrlChange}
@@ -77,7 +77,7 @@ export default function gatewaysForm ({
               type="url"
               inputmode="url"
               required
-              pattern="^https?://[^/]+/?$"
+              pattern="https?://.+"
               spellcheck="false"
               title="${browser.i18n.getMessage('option_hint_url')}"
               onchange=${onPublicSubdomainGatewayUrlChange}
@@ -99,7 +99,7 @@ export default function gatewaysForm ({
                 type="url"
                 inputmode="url"
                 required
-                pattern="^https?://[^/]+/?$"
+                pattern="https?://.+"
                 spellcheck="false"
                 title="${browser.i18n.getMessage(allowChangeOfCustomGateway ? 'option_hint_url' : 'option_hint_readonly')}"
                 onchange=${onCustomGatewayUrlChange}

--- a/add-on/src/options/store.js
+++ b/add-on/src/options/store.js
@@ -11,6 +11,12 @@ export default function optionStore (state, emitter) {
   state.options = optionDefaults
 
   const fetchRedirectRules = async () => {
+    // Check if declarativeNetRequest is supported before using it
+    if (!browser.declarativeNetRequest) {
+      state.redirectRules = []
+      return
+    }
+
     const existingRedirectRules = await browser.declarativeNetRequest.getDynamicRules()
     state.redirectRules = existingRedirectRules.map(rule => ({
       id: rule.id,


### PR DESCRIPTION
- add alarms permission for reliable background polling
- implement hybrid polling with chrome alarms api to prevent service worker dormancy
- use setinterval + alarms for <30s intervals, alarms only for ≥30s
- properly cleanup alarms and intervals when extension is disabled
- set badge to offline when disabling extension
- fix declarativenetrequest undefined error on firefox
- fix html pattern validation in url inputs
- simplify default log namespaces

Closes #1338