### PR TITLE
fix: prevent version span from affecting icon layout

### DIFF
--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -26,7 +26,7 @@ export default function header (props) {
     isIpfsOnline: (active && isIpfsOnline)
   })}
         </div>
-          <div class="flex flex-column ml2 white ${active ? '' : 'o-40'}">
+          <div class="flex flex-column ml2 white ${active ? '' : 'o-40'}" style="position: relative;">
             <div>
               <h1 class="inter fw6 f2 ttu ma0 pa0">
                 IPFS

--- a/add-on/src/popup/browser-action/ipfs-version.js
+++ b/add-on/src/popup/browser-action/ipfs-version.js
@@ -10,8 +10,8 @@ function statusEntry ({ label, labelLegend, title, value, check, valueClass = ''
   labelLegend = labelLegend ? browser.i18n.getMessage(labelLegend) : label
   value = value || value === 0 ? value : offline
   return html`
-      <div title="${labelLegend}" class="ma0 pa0" style="line-height: 0.25">
-        <span class="f7 tr monospace force-select-all ${valueClass}" title="${title}">${value.substring(0, 20)}</span>
+      <div title="${labelLegend}" class="ma0 pa0" style="position: absolute; line-height: 0.25">
+        <span class="f7 tr monospace force-select-all ${valueClass}" title="${title}">${value}</span>
       </div>
     `
 }


### PR DESCRIPTION
##  Problem

- https://github.com/ipfs/kubo/pull/9465 will limit version to 128 unicode codepoints, and longer version string breaks the layout. This PR is a fix.

## Solution

This PR is a fix:
- use absolute positioning for ipfs version display
- add relative positioning to parent container
- remove 20-character truncation from version text

## Demo

> <img width="515" height="264" alt="2025-09-17_20-30" src="https://github.com/user-attachments/assets/c3c91dd1-fa5b-44ff-9a92-5f1466752d57" />
