### PR TITLE
feat: Adding service worker gateway node type and subdomain redirection

### DIFF
--- a/add-on/src/lib/ipfs-client/index.js
+++ b/add-on/src/lib/ipfs-client/index.js
@@ -41,7 +41,10 @@ export async function destroyIpfsClient (browser) {
   log('destroy ipfs client')
   if (!client) return
   try {
-    await client.destroy(browser)
+    // Only destroy if client has a destroy method (not SW Gateway)
+    if (client.destroy) {
+      await client.destroy(browser)
+    }
     await _reloadIpfsClientDependents(browser) // sync (API stopped working)
   } finally {
     client = null

--- a/add-on/src/lib/ipfs-request-sw-gateway.js
+++ b/add-on/src/lib/ipfs-request-sw-gateway.js
@@ -1,0 +1,72 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+import debug from 'debug'
+const log = debug('ipfs-companion:sw-gateway')
+
+/**
+ * Handles Service Worker Gateway redirects
+ * @param {import('../types/companion.js').CompanionState} state
+ * @param {browser.WebRequest.OnBeforeRequestDetailsType | {url: string, type?: string}} request
+ * @returns {Object|undefined}
+ */
+export function redirectToSwGateway(state, request) {
+  // Only redirect if SW Gateway is active
+  if (!state.isServiceWorkerGateway || !state.active) {
+    return
+  }
+
+  if (!request || !request.url) {
+    return
+  }
+
+  try {
+    const url = new URL(request.url)
+    
+    // Skip if already redirected to SW gateway
+    if (url.hostname.includes('inbrowser.link') || 
+        url.hostname.includes('inbrowser.dev')) {
+      return
+    }
+
+    // Check for IPFS/IPNS paths
+    const match = url.pathname.match(/^\/(ipfs|ipns)\/([^\/]+)(\/.*)?$/)
+    if (!match) return
+
+    const [, protocol, cid, path = ''] = match
+    const gatewayUrl = state.serviceWorkerGatewayUrl || 'https://inbrowser.link'
+    const gwUrl = new URL(gatewayUrl)
+    
+    // Use PATH format instead of subdomain to preserve CID case
+    // https://inbrowser.link/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/
+    const redirectUrl = `${gwUrl.protocol}//${gwUrl.hostname}/${protocol}/${cid}${path}${url.search}${url.hash}`
+    
+    log(`Redirecting to SW Gateway: ${request.url} → ${redirectUrl}`)
+    return { redirectUrl }
+  } catch (error) {
+    log.error('Error in SW Gateway redirect:', error)
+    return
+  }
+}
+
+/**
+ * Check if feature should be disabled for SW Gateway
+ * @param {string} feature
+ * @param {import('../types/companion.js').CompanionState} state
+ * @returns {boolean}
+ */
+export function isFeatureDisabledForSwGateway(feature, state) {
+  if (!state.isServiceWorkerGateway) return false
+  
+  const disabledFeatures = [
+    'quickImport',
+    'ipfsProxy',
+    'pinning',
+    'mfsSupport',
+    'ipfsNodeInfo',
+    'swarmPeers',
+    'webui'
+  ]
+  
+  return disabledFeatures.includes(feature)
+}

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -4,7 +4,8 @@
 import { isHostname, safeURL } from './options.js'
 
 export const offlinePeerCount = -1
-export const POSSIBLE_NODE_TYPES = ['external']
+export const SERVICE_WORKER_GATEWAY_NODE = 'service_worker_gateway'
+export const POSSIBLE_NODE_TYPES = ['external',SERVICE_WORKER_GATEWAY_NODE]
 
 /**
  *
@@ -36,6 +37,18 @@ export function initState (options, overrides) {
   state.gwURLString = state.gwURL?.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
+  state.isServiceWorkerGateway =
+    options.ipfsNodeType === SERVICE_WORKER_GATEWAY_NODE
+
+  // Normalize and expose current/fallback SW gateway endpoints (keep originals too)
+  if (options.serviceWorkerGatewayUrl) {
+    state.swGwURL = safeURL(options.serviceWorkerGatewayUrl)
+    state.swGwURLString = state.swGwURL?.toString()
+  }
+  if (options.serviceWorkerGatewayFallbackUrl) {
+    state.swGwFallbackURL = safeURL(options.serviceWorkerGatewayFallbackUrl)
+    state.swGwFallbackURLString = state.swGwFallbackURL?.toString()
+  }
 
   // attach helper functions
   state.activeIntegrations = (url) => {

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -12,6 +12,73 @@ import { POSSIBLE_NODE_TYPES } from '../../lib/state.js'
 // https://github.com/ipfs-shipyard/ipfs-companion/issues/648
 const secureContextUrl = /^https:\/\/|^http:\/\/localhost|^http:\/\/127.0.0.1|^http:\/\/\[::1\]/
 
+// Add this function before the export default
+function renderServiceWorkerGatewayOptions({
+  ipfsNodeType,
+  serviceWorkerGatewayUrl,
+  onOptionChange
+}) {
+  const isSwGateway = ipfsNodeType === 'service_worker_gateway'
+  const onSwGatewayUrlChange = onOptionChange('serviceWorkerGatewayUrl', guiURLString)
+  
+  if (!isSwGateway) return null
+  
+  return html`
+    <div class="flex-row-ns pb0-ns">
+      <label for="serviceWorkerGatewayUrl">
+        <dl>
+          <dt>Service Worker Gateway URL</dt>
+          <dd>
+            The Service Worker Gateway endpoint for trustless content retrieval.
+            <div class="mt2">
+              <button
+                type="button"
+                class="button-reset pv1 ph2 ba b--gray hover-bg-light-gray"
+                onclick=${() => {
+                  const el = document.getElementById('serviceWorkerGatewayUrl')
+                  el.value = 'https://inbrowser.link'
+                  el.dispatchEvent(new Event('change', { bubbles: true }))
+                }}>
+                Use Production
+              </button>
+
+              <button
+                type="button"
+                class="ml2 button-reset pv1 ph2 ba b--gray hover-bg-light-gray"
+                onclick=${() => {
+                  const el = document.getElementById('serviceWorkerGatewayUrl')
+                  el.value = 'https://inbrowser.dev'
+                  el.dispatchEvent(new Event('change', { bubbles: true }))
+                }}>
+                Use Staging
+              </button>
+            </div>
+          </dd>
+        </dl>
+      </label>
+      <input
+        class="bg-white navy self-center-ns"
+        id="serviceWorkerGatewayUrl"
+        type="url"
+        inputmode="url"
+        required
+        pattern="https?://.+"
+        spellcheck="false"
+        title="Service Worker Gateway URL"
+        onchange=${onSwGatewayUrlChange}
+        value=${serviceWorkerGatewayUrl || 'https://inbrowser.link'} />
+    </div>
+    <div class="pa3 bg-washed-yellow navy br2 f6">
+      <strong>ℹ️ Service Worker Gateway Mode:</strong>
+      <ul class="mt2 mb0 pl3">
+        <li>Provides trustless, browser-based IPFS content fetching</li>
+        <li>Upload and pinning features are disabled in this mode</li>
+        <li>No local IPFS node required</li>
+      </ul>
+    </div>
+  `
+}
+
 export default function gatewaysForm ({
   ipfsNodeType,
   customGatewayUrl,
@@ -21,7 +88,8 @@ export default function gatewaysForm ({
   enabledOn,
   publicGatewayUrl,
   publicSubdomainGatewayUrl,
-  onOptionChange
+  onOptionChange,
+  serviceWorkerGatewayUrl
 }) {
   const onCustomGatewayUrlChange = onOptionChange('customGatewayUrl', (url) => guiURLString(url, { useLocalhostName: useSubdomains }))
   const onUseCustomGatewayChange = onOptionChange('useCustomGateway')
@@ -38,6 +106,7 @@ export default function gatewaysForm ({
     <form>
       <fieldset class="mb3 pa1 pa4-ns pa3 bg-snow-muted charcoal">
         <h2 class="ttu tracked f6 fw4 teal mt0-ns mb3-ns mb1 mt2 ">${browser.i18n.getMessage('option_header_gateways')}</h2>
+        ${renderServiceWorkerGatewayOptions({ ipfsNodeType, serviceWorkerGatewayUrl, onOptionChange })}
           <div class="flex-row-ns pb0-ns">
             <label for="publicGatewayUrl">
               <dl>

--- a/add-on/src/options/forms/ipfs-node-form.js
+++ b/add-on/src/options/forms/ipfs-node-form.js
@@ -25,6 +25,11 @@ export default function ipfsNodeForm ({ ipfsNodeType, onOptionChange }) {
               selected=${ipfsNodeType === 'external'}>
               ${browser.i18n.getMessage('option_ipfsNodeType_external')}
             </option>
+            <option
+              value='service_worker_gateway'
+              selected=${ipfsNodeType === 'service_worker_gateway'}>
+              Service Worker Gateway (Trustless)
+            </option>
           </select>
         </div>
       </fieldset>

--- a/add-on/src/types/companion.d.ts
+++ b/add-on/src/types/companion.d.ts
@@ -1,7 +1,6 @@
 
 export interface CompanionOptions {
   active: boolean
-  ipfsNodeType: string
   ipfsNodeConfig: string
   publicGatewayUrl: string
   publicSubdomainGatewayUrl: string
@@ -27,7 +26,10 @@ export interface CompanionOptions {
   importDir: string
   useLatestWebUI: boolean
   dismissedUpdate: null | string
-  openViaWebUI: boolean
+  openViaWebUI: boolean,
+  ipfsNodeType: 'external' | 'service_worker_gateway'
+  serviceWorkerGatewayUrl: string
+  serviceWorkerGatewayFallbackUrl: string
 }
 
 export interface CompanionState extends Omit<CompanionOptions, 'publicGatewayUrl' | 'publicSubdomainGatewayUrl' | 'useCustomGateway' | 'ipfsApiUrl' | 'customGatewayUrl'> {
@@ -43,7 +45,13 @@ export interface CompanionState extends Omit<CompanionOptions, 'publicGatewayUrl
   gwURLString: string
   activeIntegrations: (url: string) => boolean
   localGwAvailable: boolean
-  webuiRootUrl: string
+  webuiRootUrl: string | null
+  nodeActive: boolean 
+  isServiceWorkerGateway?: boolean
+  swGwURL?: URL
+  swGwURLString?: string
+  swGwFallbackURL?: URL
+  swGwFallbackURLString?: string
 }
 
 interface SwitchToggleArguments {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@istanbuljs/esm-loader-hook": "0.2.0",
         "@types/chai": "4.3.20",
         "@types/debug": "4.1.12",
+        "@types/is-fqdn": "^2.0.0",
         "@types/mocha": "10.0.10",
         "@types/selenium-webdriver": "4.1.28",
         "@types/webextension-polyfill": "0.10.7",
@@ -2923,6 +2924,13 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/is-fqdn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/is-fqdn/-/is-fqdn-2.0.0.tgz",
+      "integrity": "sha512-SOu3hvVxVptGQx9YpAI/OYW0jzjRW3B/2zxoMfBf3bvcEe4OzS6lWgKb1WPqsi60n0r3w4RjhJjSQyqfB3feSw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@istanbuljs/esm-loader-hook": "0.2.0",
     "@types/chai": "4.3.20",
     "@types/debug": "4.1.12",
+    "@types/is-fqdn": "^2.0.0",
     "@types/mocha": "10.0.10",
     "@types/selenium-webdriver": "4.1.28",
     "@types/webextension-polyfill": "0.10.7",


### PR DESCRIPTION
Fixes #1336

### Description
Adds a new **Service Worker Gateway** node type to IPFS Companion, enabling trustless, browser-based IPFS content fetching without requiring a local IPFS node.

### Implementation
- Added `service_worker_gateway` as a new node type option
- Redirects IPFS/IPNS requests to configured SW gateway (default: https://inbrowser.link)
- Disables publishing features (upload, pinning, WebUI) when SW Gateway is active
- Added UI for configuring gateway URL with production/staging options

### Testing
- [x] Redirect functionality works for IPFS/IPNS paths
- [x] Settings persist across browser restarts
- [x] Publishing features properly disabled
- [x] Node type switching works correctly

### Known Limitations
- Service Worker Gateway (inbrowser.link) may have issues some resources may return 501/504 errors from the gateway service itself

### Screen Recording

https://github.com/user-attachments/assets/1f3c6640-7068-4840-bece-9173e0f70261

Reviewer: @lidel 

